### PR TITLE
fix cell selectedPosition access level

### DIFF
--- a/Sources/PickableCell.swift
+++ b/Sources/PickableCell.swift
@@ -65,7 +65,7 @@ open class PickableCell: UICollectionViewCell {
 
     var selectedBorderWidth: CGFloat = 4.0
 
-    var selectedPosition: Int = -1 {
+    internal(set) public var selectedPosition: Int = -1 {
         didSet {
             updateSelectedPosition()
         }


### PR DESCRIPTION
I want to use custom selectedPosition label.
So I need read access level to selectedPosition at PickableCell.
In this changes, write access level is still in internal.