### PR TITLE
fix updateSelectedPosition access level

### DIFF
--- a/Sources/PickableCell.swift
+++ b/Sources/PickableCell.swift
@@ -114,7 +114,7 @@ open class PickableCell: UICollectionViewCell {
 
     }
 
-    private func updateSelectedPosition() {
+    open func updateSelectedPosition() {
         if showsSelectedPosition && selectedPosition != -1 {
             positionLabel.text = "\(selectedPosition)"
             positionLabel.isHidden = false


### PR DESCRIPTION
I want to override updateSelectedPosition method in PickableCell.
So I fixed access level from private to open.